### PR TITLE
Added a button to save unpacked .SND file

### DIFF
--- a/SndhArchivePlayer.vcxproj
+++ b/SndhArchivePlayer.vcxproj
@@ -168,6 +168,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)\SndhArchivePlayer\extern\imgui\backends;$(SolutionDir)\SndhArchivePlayer\extern\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -184,6 +185,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)\SndhArchivePlayer\extern\imgui\backends;$(SolutionDir)\SndhArchivePlayer\extern\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/SndhArchivePlayer/AsyncSndhStream.h
+++ b/SndhArchivePlayer/AsyncSndhStream.h
@@ -6,12 +6,17 @@
 #include <atomic>
 #include "../AtariAudio/AtariAudio.h"
 
+#include <string>
+#include <filesystem>
+#include <vector>
+
+class SndhArchive;
+
 class AsyncSndhStream
 {
 public:
 
 	~AsyncSndhStream();
-	AsyncSndhStream();
 
 	bool LoadSndh(const void* sndhFile, int fileSize, uint32_t replayRate);
 	void Unload();
@@ -25,7 +30,7 @@ public:
 	bool	GetSubsongInfo(int subSongId, SndhFile::SubSongInfo& out) const;
 	const void* GetRawData(int& fileSize) const;
 
-	void	DrawGui(const char* musicName);
+	void	DrawGui(const char* musicName, const SndhArchive& archive);
 
 	static void sAsyncSndhWorkerThread(void* a);
 
@@ -33,27 +38,35 @@ private:
 	void SetReplayPosInSec(int pos);
 	void CloseSubsong();
 	void AsyncWorkerFunction();
+	void DrawFileSelector();
 
 	struct AsyncInfo
 	{
 		std::atomic <uint32_t> fillPos;
-		std::thread*	thread;
-		std::atomic<bool> forceQuit;
+		std::thread* thread{ nullptr };
+		std::atomic<bool> forceQuit{ false };
 		std::atomic<int> progress;
 		SndhFile sndh;
 	};
 
-	bool m_bLoaded;
-	int m_lenInSec;
-	int playOffsetInSec;
+	int m_lenInSec = 0;
+	int playOffsetInSec = 0;
 	HWAVEOUT	m_waveOutHandle;
 	WAVEHDR		m_waveHeader;
-	int16_t*	m_audioBuffer;
-	uint32_t*	m_audioDebugBuffer;
-	uint32_t 	m_audioBufferLen;
-	uint32_t	m_replayRate;
-	bool		m_paused;
-	bool		m_saved;
+	int16_t*	m_audioBuffer = nullptr;
+	uint32_t*	m_audioDebugBuffer = nullptr;
+	uint32_t 	m_audioBufferLen = 0;
+	uint32_t	m_replayRate = 0;
+	bool		m_bLoaded = false;
+	bool		m_paused = false;
+	bool		m_saved = false;
+	bool		m_rawSaved = false;
+	bool		m_showFileSelector = false;
 
 	AsyncInfo m_asyncInfo;
+
+	// Data for the file selector ImGui
+	std::filesystem::path m_currentPath;
+	std::string m_selectedFile;
+	std::vector<std::filesystem::directory_entry> m_currentEntries;
 };

--- a/SndhArchivePlayer/SndhArchive.cpp
+++ b/SndhArchivePlayer/SndhArchive.cpp
@@ -101,6 +101,8 @@ bool	SndhArchive::Open(const char* sFilename)
 	m_zipArchive = zip_open(sFilename, 0, 'r');
 	if (m_zipArchive)
 	{
+		m_filename = std::string(sFilename);
+
 		int entryCount = int(zip_entries_total(m_zipArchive));
 		m_list = (PlayListItem*)malloc(entryCount * sizeof(PlayListItem));
 		memset(m_list, 0, entryCount * sizeof(PlayListItem));
@@ -135,6 +137,11 @@ bool	SndhArchive::Open(const char* sFilename)
 			ret = true;
 		}
 	}
+	else
+	{
+		m_filename = std::string();
+	}
+
 	return ret;
 }
 

--- a/SndhArchivePlayer/SndhArchive.h
+++ b/SndhArchivePlayer/SndhArchive.h
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <thread>
 #include <atomic>
+#include <string>
 #include "imgui_internal.h"
 #include "extern/zip/src/zip.h"
 #include "jobSystem.h"
@@ -25,6 +26,7 @@ public:
 	void	ImGuiDraw(SndhArchivePlayer& player);
 	bool	IsOpen() const { return m_zipArchive != NULL; }
 	bool	IsOpening() const { return m_asyncBrowse; }
+	std::string GetFilename() const { return IsOpen() ? m_filename : std::string(""); }
 
 private:
 	struct PlayListItem
@@ -80,6 +82,7 @@ private:
 	bool LoadZipEnd();
 	int m_zipWorkersCount;
 	bool m_asyncBrowse;
+	std::string m_filename;
 	std::atomic<int> m_progress;
 	bool m_firstSearchFocus;
 

--- a/SndhArchivePlayer/SndhArchivePlayer.cpp
+++ b/SndhArchivePlayer/SndhArchivePlayer.cpp
@@ -392,7 +392,7 @@ void	SndhArchivePlayer::UpdateImGui()
 						StartSubsong(newSubsong);
 				}
 				ImGui::EndTable();
-				m_sndh.DrawGui(info.musicName);
+				m_sndh.DrawGui(info.musicName, gArchive);
 			}
 		}
 


### PR DESCRIPTION
Saves the file in the same directory as the archive by default, but provides an ImGui file selector to choose a different name or directory.

Requires C++17 for the filesystem module.

Fixes space at the end of music names for some files.

Replaced some in-constructor initialisations with inline initialisations whilst I was adding a new member variable.
